### PR TITLE
Make sure .js target is the suffix, or it'll match any old file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "main": "index.js",
   "name": "jsx-vanilla-loader",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/AdeonMaster/jsx-vanilla-loader.git"

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ module.exports = {
 	devtool : 'source-map',
 	entry: {
 		main: "./src/main.js"
-	}, 
+	},
 	output: {
 		path: path.resolve(__dirname, '../js'),
 		filename: "[name].js"
@@ -20,12 +20,12 @@ module.exports = {
 	module : {
     rules : [
 		{
-        test : /\.js?/,
+        test : /\.js$/,
         include : path.resolve(__dirname, "src"),
         loader : 'jsx-vanilla-loader'
       }
     ]
   }
 }
-	
+
 ```


### PR DESCRIPTION
I'd possibly even suggest a file extension of `.jsx`, which is gaining popularity and avoids conflict with .js